### PR TITLE
[-] MO : Allow columns theme checkbox

### DIFF
--- a/loyalty.php
+++ b/loyalty.php
@@ -46,6 +46,8 @@ class Loyalty extends Module
 		$this->author = 'PrestaShop';
 		$this->need_instance = 0;
 
+		$this->controllers = array('default');
+
 		$this->bootstrap = true;
 		parent::__construct();
 


### PR DESCRIPTION
Without this line, this module line is not shown in the Theme > Columns appearence.
But we need to manage left / right columns for loyalty page ! (in my account front section).