### PR TITLE
Fix loyalty points calculation per order

### DIFF
--- a/LoyaltyModule.php
+++ b/LoyaltyModule.php
@@ -77,7 +77,16 @@ class LoyaltyModule extends ObjectModel
 	{
 		if (!Validate::isLoadedObject($order))
 			return false;
-		return self::getCartNbPoints(new Cart((int)$order->id_cart));
+		
+		$total_paid = 0;
+		$taxesEnabled = Product::getTaxCalculationMethod();
+		if ($taxesEnabled == PS_TAX_EXC){
+			$total_paid += $order->total_paid_tax_excl;
+		} else {
+			$total_paid += $order->total_paid_tax_incl;
+		}
+
+		return self::getNbPointsByPrice($total_paid);
 	}
 
 	public static function getCartNbPoints($cart, $newProduct = NULL)


### PR DESCRIPTION
The method _getOrderNbPoints_ would return the amount of points based on the _cart price_. **That is not always correct**. In a shop configured with multiple warehouses a single cart may result in multiple orders. So actually the price of each order is smaller than the price of the cart.  And in this case, for each single order the customer would be "awarded" based on the full price of the cart , instead of the individual order price. The fix applied reads the value from the order itself, applying taxes if that's the case. 
